### PR TITLE
fix TextSplitter bug

### DIFF
--- a/src/TextSplitter.ts
+++ b/src/TextSplitter.ts
@@ -50,7 +50,7 @@ export class TextSplitter {
         function getOverlapTokens(tokens?: number[]): number[] {
             if (tokens != undefined) {
                 const len = tokens.length > that._config.chunkOverlap ? that._config.chunkOverlap : tokens.length;
-                return tokens.slice(tokens.length);
+                return tokens.slice(0, len);
             } else {
                 return [];
             }


### PR DESCRIPTION
`tokens.slice(tokens.length)` always returns the empty array.

- Using `len` variable defined in the previous line.
- Update usage to start slice from index 0