### PR TITLE
Fixed metadata index bug in LocalIndex.ts

### DIFF
--- a/src/LocalIndex.ts
+++ b/src/LocalIndex.ts
@@ -350,7 +350,7 @@ export class LocalIndex<TMetadata extends Record<string,MetadataTypes> = Record<
             }
 
             // Save remaining metadata to disk
-            metadataFile = `${v4}.json`;
+            metadataFile = `${v4()}.json`;
             const metadataPath = path.join(this._folderPath, metadataFile);
             await fs.writeFile(metadataPath, JSON.stringify(item.metadata));
         } else if (item.metadata) {


### PR DESCRIPTION
The UUID method wasn't called, causing an error when caching the metadata. 

I would love your thoughts on whether to keep this functionality or remove/clean it for increased simplicity. Granted no-one has used this in over a year because it wasn't working. I can see about doing that if you're willing.

Anyway, great work on this project!