### PR TITLE
Fixed Typescript error in ItemSelector.ts

### DIFF
--- a/src/ItemSelector.ts
+++ b/src/ItemSelector.ts
@@ -155,7 +155,7 @@ export class ItemSelector {
                     else if (typeof value == 'string' && filter[key]!.includes(value)) {
                         return false;
                     }
-                    else if (filter[key]!.some(val => typeof val == 'string' && val.includes(value))) {
+                    else if (filter[key]!.some(val => typeof val == 'string' && val.includes(value as string))) {
                         return false;
                     }
                     break;


### PR DESCRIPTION
I see that this cast was removed, but Typescript is giving me errors without this string cast. Simply reintroducing what was, perhaps accidentally, removed.