### PR TITLE
Add batch insert function to LocalIndex

### DIFF
--- a/src/LocalIndex.ts
+++ b/src/LocalIndex.ts
@@ -66,7 +66,7 @@ export class LocalIndex<TMetadata extends Record<string,MetadataTypes> = Record<
         }
 
         await this.loadIndexData();
-        this._update = Object.assign({}, this._data);
+        this._update = Object.assign({}, structuredClone(this._data));
     }
 
     /**

--- a/tests/LocalIndex.test.ts
+++ b/tests/LocalIndex.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert'
+import { LocalIndex, IndexItem } from '../lib/LocalIndex'
+import fs from 'fs/promises'
+import path from 'path'
+
+describe('LocalIndex', () => {
+  const testIndexDir = path.join(__dirname, 'test_index');
+
+  beforeEach(async () => {
+    await fs.rm(testIndexDir, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(testIndexDir, { recursive: true, force: true });
+  });
+
+  it('should create a new index', async () => {
+    const index = new LocalIndex(testIndexDir);
+    await index.createIndex();
+    const created = await index.isIndexCreated();
+    assert.equal(created, true);
+  });
+
+  describe('batchInsertItems', () => {
+    const indexItems: Partial<IndexItem>[] = [
+      { id: '1', vector: [1, 2, 3] },
+      { id: '2', vector: [2, 3, 4] },
+      { id: '3', vector: [3, 4, 5] }
+    ];
+
+    it('should insert provided items', async () => {
+      const index = new LocalIndex(testIndexDir);
+      await index.createIndex();
+
+      const newItems = await index.batchInsertItems(indexItems);
+
+      assert.equal(newItems.length, 3);
+
+      const retrievedItems = await index.listItems();
+      assert.equal(retrievedItems.length, 3);
+    });
+
+    it('on id collision - cancel batch insert & bubble up error', async () => {
+      debugger
+      const index = new LocalIndex(testIndexDir);
+      await index.createIndex();
+
+      await index.insertItem({ id: '2', vector: [9, 9, 9] });
+
+      // ensures insert error is bubbled up to batchIndexItems caller
+      await assert.rejects(
+        async () => {
+          await index.batchInsertItems(indexItems);
+        },
+        {
+          name: 'Error',
+          message: 'Item with id 2 already exists'
+        }
+      );
+
+      // ensures no partial update is applied
+      const storedItems = await index.listItems();
+      assert.equal(storedItems.length, 1);
+    });
+  });
+});


### PR DESCRIPTION
Batch insert would be very useful to us as we use Vectra to prototype RAG solutions and tend to load in a large amount of data at once.

Setup tests using node:assert to avoid modifying dependencies. Provided test cases pass
<img width="947" height="303" alt="Screenshot 2025-08-31 170022" src="https://github.com/user-attachments/assets/cd3ad68c-e396-429a-888a-3efbf1954293" />

Also fixed an bug where the `items` array on `_data` was being passed by reference in the call to `Object.assign`. This was causing the third test case to fail because any mutation of `this._update.items` was also mutating `this._data.items` (see debug repl below).
<img width="992" height="653" alt="Screenshot 2025-08-31 165722" src="https://github.com/user-attachments/assets/df9b2b63-0dc1-454c-ae79-03512bf5815a" />